### PR TITLE
Set YouTube playlist maxResults parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
     - rust: nightly
 script:
   - cargo build --verbose
-  - cargo test --verbose
+  - RUST_BACKTRACE=1 cargo test --verbose -- --nocapture
   - nvm install 7.4.0
   - npm install -g yarn
   - yarn install

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,5 @@ script:
   - yarn install
   - npm run lint
   - npm test
+env:
+  secure: arNYn6yIGZnbEJGy9WhpKlhWyOT22ZF8hjBqCXNl8itFv4qBgl8WKvn4erx+T45vLTe95FNCZKoDdmg386yAwhy6FEbdDj1DTudP4zU0go5yAH28LNmcN2cpnjFoP/sFOmYnttoEXGMRnF0aFil65f+v0f4xviOzz0Pdbzx8dpw=

--- a/src/scraper.rs
+++ b/src/scraper.rs
@@ -210,7 +210,6 @@ fn extract_tracks_from_url(url: String) -> Vec<Track> {
     }
     match extract_identifier(&decoded, SOUNDCLOUD_USER) {
         Some(identifier) => {
-            print!("user {}", identifier);
             return match soundcloud::fetch_user_tracks(&identifier) {
                 Ok(tracks) => tracks.iter()
                                     .map(|ref t| Track::from_sc_track(t))

--- a/src/scraper.rs
+++ b/src/scraper.rs
@@ -225,7 +225,9 @@ fn extract_tracks_from_url(url: String) -> Vec<Track> {
 
 #[cfg(test)]
 mod test {
+    use super::extract;
     use super::extract_identifier;
+    use Provider;
 
     #[test]
     fn test_extract_identifier() {
@@ -251,5 +253,15 @@ mod test {
             Some(identifier) => assert_eq!(identifier, "PLy8LZ8FM-o0ViuGAF68RAaXkQ8V-3dbTX".to_string()),
             None             => assert!(false)
         }
+    }
+    #[test]
+    fn test_extract() {
+        let url = "http://spincoaster.com/spincoaster-breakout-2017";
+        let product = extract(url).unwrap();
+        for track in product.tracks.iter() {
+            assert_eq!(track.provider, Provider::YouTube)
+        }
+        assert_eq!(product.tracks.len(), 15);
+        assert!(true);
     }
 }


### PR DESCRIPTION
YouTube data API response are paginated with `maxResults` number.
Currently default value is 5, It is too small for us. So set `maxResults` explicitly with 50